### PR TITLE
feat: add hemizygous allele counts and freqs to protobuf

### DIFF
--- a/protos/annonars/gnomad/gnomad_sv2.proto
+++ b/protos/annonars/gnomad/gnomad_sv2.proto
@@ -126,6 +126,14 @@ message AlleleCounts {
     float freq_het = 9;
     // Homozygous alternate genotype frequency (biallelic sites only).
     float freq_homalt = 10;
+    // Number of individuals with hemizygous reference genotypes (biallelic sites only)
+    int32 n_hemiref = 11;
+    // Number of individuals with hemizygous alternate genotypes (biallelic sites only)
+    int32 n_hemialt = 12;
+    // Hemizygous reference genotype frequency (biallelic sites only).
+    float freq_hemiref = 13;
+    // Hemizygous alternate genotype frequency (biallelic sites only).
+    float freq_hemialt = 14;
 }
 
 // Store the allele counts for the given sub cohort and sub cohort factored by sex.

--- a/src/gnomad_sv/cli/import/gnomad_sv2.rs
+++ b/src/gnomad_sv/cli/import/gnomad_sv2.rs
@@ -263,10 +263,15 @@ impl Record {
         let n_homref = get_i32(record, &key("N_HOMREF")).unwrap_or_default();
         let n_het = get_i32(record, &key("N_HET")).unwrap_or_default();
         let n_homalt = get_i32(record, &key("N_HOMALT")).unwrap_or_default();
+        let n_hemiref = get_i32(record, &key("N_HEMIREF")).unwrap_or_default();
+        let n_hemialt = get_i32(record, &key("N_HEMIALT")).unwrap_or_default();
+
         let af = get_f32(record, &key("AF")).unwrap_or_default();
         let freq_homref = get_f32(record, &key("FREQ_HOMREF")).unwrap_or_default();
         let freq_het = get_f32(record, &key("FREQ_HET")).unwrap_or_default();
         let freq_homalt = get_f32(record, &key("FREQ_HOMALT")).unwrap_or_default();
+        let freq_hemiref = get_f32(record, &key("FREQ_HEMIREF")).unwrap_or_default();
+        let freq_hemialt = get_f32(record, &key("FREQ_HEMIALT")).unwrap_or_default();
 
         Ok(AlleleCounts {
             ac,
@@ -279,6 +284,10 @@ impl Record {
             freq_homref,
             freq_het,
             freq_homalt,
+            n_hemiref,
+            n_hemialt,
+            freq_hemiref,
+            freq_hemialt,
         })
     }
 


### PR DESCRIPTION
Extract `N_HEMI{REF,ALT}`  from gnomad SV v2 sources.

Related to https://github.com/varfish-org/varfish-server/issues/1836
