### PR TITLE
fix: Correct the entrypoint command

### DIFF
--- a/utils/docker/entrypoint.sh
+++ b/utils/docker/entrypoint.sh
@@ -74,7 +74,7 @@ if [ "$first" == exec ]; then
 else
   exec \
     annonars \
-    run-server \
+    server run \
       $(test -e $PATH_DB_CLINVAR_37 && echo --path-clinvar $PATH_DB_CLINVAR_37) \
       $(test -e $PATH_DB_CLINVAR_38 && echo --path-clinvar $PATH_DB_CLINVAR_38) \
       $(test -e $PATH_DB_CLINVAR_SV_37 && echo --path-clinvar-sv $PATH_DB_CLINVAR_SV_37) \


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->
While running the annonars service in reev-docker-compose suite, the following error was encountered:
```sh
annonars  | + set -euo pipefail
annonars  | + PATH_DB_BASE=/data/annonars
annonars  | + HTTP_HOST=0.0.0.0
annonars  | + HTTP_PORT=8080
annonars  | + PATH_DB_CLINVAR_37=/data/annonars/grch37/clinvar/rocksdb
annonars  | + PATH_DB_CLINVAR_38=/data/annonars/grch38/clinvar/rocksdb
annonars  | + PATH_DB_CLINVAR_SV_37=/data/annonars/grch37/clinvar-sv/rocksdb
annonars  | + PATH_DB_CLINVAR_SV_38=/data/annonars/grch38/clinvar-sv/rocksdb
annonars  | + PATH_DB_CADD_37=/data/annonars/grch37/cadd/rocksdb
annonars  | + PATH_DB_CADD_38=/data/annonars/grch38/cadd/rocksdb
annonars  | + PATH_DB_DBSNP_37=/data/annonars/grch37/dbsnp/rocksdb
annonars  | + PATH_DB_DBSNP_38=/data/annonars/grch38/dbsnp/rocksdb
annonars  | + PATH_DB_DBNSFP_37=/data/annonars/grch37/dbnsfp/rocksdb
annonars  | + PATH_DB_DBNSFP_38=/data/annonars/grch38/dbnsfp/rocksdb
annonars  | + PATH_DB_DBSCSNV_37=/data/annonars/grch37/dbscsnv/rocksdb
annonars  | + PATH_DB_DBSCSNV_38=/data/annonars/grch38/dbscsnv/rocksdb
annonars  | + PATH_DB_GNOMAD_MTDNA_37=/data/annonars/grch37/gnomad-mtdna/rocksdb
annonars  | + PATH_DB_GNOMAD_MTDNA_38=/data/annonars/grch38/gnomad-mtdna/rocksdb
annonars  | + PATH_DB_GNOMAD_EXOMES_37=/data/annonars/grch37/gnomad-exomes/rocksdb
annonars  | + PATH_DB_GNOMAD_EXOMES_38=/data/annonars/grch38/gnomad-exomes/rocksdb
annonars  | + PATH_DB_GNOMAD_GENOMES_37=/data/annonars/grch37/gnomad-genomes/rocksdb
annonars  | + PATH_DB_GNOMAD_GENOMES_38=/data/annonars/grch38/gnomad-genomes/rocksdb
annonars  | + PATH_DB_HELIXMTDB_37=/data/annonars/grch37/helixmtdb/rocksdb
annonars  | + PATH_DB_HELIXMTDB_38=/data/annonars/grch38/helixmtdb/rocksdb
annonars  | + PATH_DB_CONS_37=/data/annonars/grch37/cons/rocksdb
annonars  | + PATH_DB_CONS_38=/data/annonars/grch38/cons/rocksdb
annonars  | + PATH_GENES=/data/annonars/genes/rocksdb
annonars  | + PATH_GENES_CLINVAR=/data/annonars/clinvar-genes/rocksdb
annonars  | + first=
annonars  | + '[' '' == exec ']'
annonars  | ++ test -e /data/annonars/grch37/clinvar/rocksdb
annonars  | ++ echo --path-clinvar /data/annonars/grch37/clinvar/rocksdb
annonars  | ++ test -e /data/annonars/grch38/clinvar/rocksdb
annonars  | ++ echo --path-clinvar /data/annonars/grch38/clinvar/rocksdb
annonars  | ++ test -e /data/annonars/grch37/clinvar-sv/rocksdb
annonars  | ++ echo --path-clinvar-sv /data/annonars/grch37/clinvar-sv/rocksdb
annonars  | ++ test -e /data/annonars/grch38/clinvar-sv/rocksdb
annonars  | ++ echo --path-clinvar-sv /data/annonars/grch38/clinvar-sv/rocksdb
annonars  | ++ test -e /data/annonars/grch37/cadd/rocksdb
annonars  | ++ echo --path-cadd /data/annonars/grch37/cadd/rocksdb
annonars  | ++ test -e /data/annonars/grch38/cadd/rocksdb
annonars  | ++ echo --path-cadd /data/annonars/grch38/cadd/rocksdb
annonars  | ++ test -e /data/annonars/grch37/dbsnp/rocksdb
annonars  | ++ echo --path-dbsnp /data/annonars/grch37/dbsnp/rocksdb
annonars  | ++ test -e /data/annonars/grch38/dbsnp/rocksdb
annonars  | ++ echo --path-dbsnp /data/annonars/grch38/dbsnp/rocksdb
annonars  | ++ test -e /data/annonars/grch37/dbnsfp/rocksdb
annonars  | ++ echo --path-dbnsfp /data/annonars/grch37/dbnsfp/rocksdb
annonars  | ++ test -e /data/annonars/grch38/dbnsfp/rocksdb
annonars  | ++ echo --path-dbnsfp /data/annonars/grch38/dbnsfp/rocksdb
annonars  | ++ test -e /data/annonars/grch37/dbscsnv/rocksdb
annonars  | ++ echo --path-dbscsnv /data/annonars/grch37/dbscsnv/rocksdb
annonars  | ++ test -e /data/annonars/grch38/dbscsnv/rocksdb
annonars  | ++ echo --path-dbscsnv /data/annonars/grch38/dbscsnv/rocksdb
annonars  | ++ test -e /data/annonars/grch37/gnomad-mtdna/rocksdb
annonars  | ++ echo --path-gnomad-mtdna /data/annonars/grch37/gnomad-mtdna/rocksdb
annonars  | ++ test -e /data/annonars/grch38/gnomad-mtdna/rocksdb
annonars  | ++ echo --path-gnomad-mtdna /data/annonars/grch38/gnomad-mtdna/rocksdb
annonars  | ++ test -e /data/annonars/grch37/gnomad-exomes/rocksdb
annonars  | ++ echo --path-gnomad-exomes /data/annonars/grch37/gnomad-exomes/rocksdb
annonars  | ++ test -e /data/annonars/grch38/gnomad-exomes/rocksdb
annonars  | ++ echo --path-gnomad-exomes /data/annonars/grch38/gnomad-exomes/rocksdb
annonars  | ++ test -e /data/annonars/grch37/gnomad-genomes/rocksdb
annonars  | ++ echo --path-gnomad-genomes /data/annonars/grch37/gnomad-genomes/rocksdb
annonars  | ++ test -e /data/annonars/grch38/gnomad-genomes/rocksdb
annonars  | ++ echo --path-gnomad-genomes /data/annonars/grch38/gnomad-genomes/rocksdb
annonars  | ++ test -e /data/annonars/grch37/helixmtdb/rocksdb
annonars  | ++ echo --path-helixmtdb /data/annonars/grch37/helixmtdb/rocksdb
annonars  | ++ test -e /data/annonars/grch38/helixmtdb/rocksdb
annonars  | ++ echo --path-helixmtdb /data/annonars/grch38/helixmtdb/rocksdb
annonars  | ++ test -e /data/annonars/grch37/cons/rocksdb
annonars  | ++ echo --path-ucsc-conservation /data/annonars/grch37/cons/rocksdb
annonars  | ++ test -e /data/annonars/grch38/cons/rocksdb
annonars  | ++ echo --path-ucsc-conservation /data/annonars/grch38/cons/rocksdb
annonars  | ++ test -e /data/annonars/genes/rocksdb
annonars  | ++ echo --path-genes /data/annonars/genes/rocksdb
annonars  | ++ test -e /data/annonars/clinvar-genes/rocksdb
annonars  | ++ echo --path-clinvar-genes /data/annonars/clinvar-genes/rocksdb
annonars  | + exec annonars run-server --path-clinvar /data/annonars/grch37/clinvar/rocksdb --path-clinvar /data/annonars/grch38/clinvar/rocksdb --path-clinvar-sv /data/annonars/grch37/clinvar-sv/rocksdb --path-clinvar-sv /data/annonars/grch38/clinvar-sv/rocksdb --path-cadd /data/annonars/grch37/cadd/rocksdb --path-cadd /data/annonars/grch38/cadd/rocksdb --path-dbsnp /data/annonars/grch37/dbsnp/rocksdb --path-dbsnp /data/annonars/grch38/dbsnp/rocksdb --path-dbnsfp /data/annonars/grch37/dbnsfp/rocksdb --path-dbnsfp /data/annonars/grch38/dbnsfp/rocksdb --path-dbscsnv /data/annonars/grch37/dbscsnv/rocksdb --path-dbscsnv /data/annonars/grch38/dbscsnv/rocksdb --path-gnomad-mtdna /data/annonars/grch37/gnomad-mtdna/rocksdb --path-gnomad-mtdna /data/annonars/grch38/gnomad-mtdna/rocksdb --path-gnomad-exomes /data/annonars/grch37/gnomad-exomes/rocksdb --path-gnomad-exomes /data/annonars/grch38/gnomad-exomes/rocksdb --path-gnomad-genomes /data/annonars/grch37/gnomad-genomes/rocksdb --path-gnomad-genomes /data/annonars/grch38/gnomad-genomes/rocksdb --path-helixmtdb /data/annonars/grch37/helixmtdb/rocksdb --path-helixmtdb /data/annonars/grch38/helixmtdb/rocksdb --path-ucsc-conservation /data/annonars/grch37/cons/rocksdb --path-ucsc-conservation /data/annonars/grch38/cons/rocksdb --path-genes /data/annonars/genes/rocksdb --path-clinvar-genes /data/annonars/clinvar-genes/rocksdb --listen-host 0.0.0.0 --listen-port 8080
annonars  | error: unrecognized subcommand 'run-server'
annonars  |
annonars  |   tip: a similar subcommand exists: 'server'
annonars  |
annonars  | Usage: annonars [OPTIONS] <COMMAND>
annonars  |
annonars  | For more information, try '--help'.
```


The provided fix worked for me. Please, review and merge as needed.