### PR TITLE
fix: re-enable gnomad output for server

### DIFF
--- a/src/server/run/annos_variant.rs
+++ b/src/server/run/annos_variant.rs
@@ -3068,7 +3068,6 @@ pub async fn handle_with_openapi(
             })
             .transpose()?
             .flatten(),
-        ..Default::default()
     };
 
     Ok(Json(SeqvarsAnnosResponse { result }))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for annotations from gnomAD exomes and genomes databases, providing more comprehensive variant information.
	- Updated response structure now includes results from gnomAD along with existing annotations from CADD, dbSNP, and ClinVar.

- **Bug Fixes**
	- Improved error handling for database version fetching, ensuring robustness in response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->